### PR TITLE
fix: render.yaml HF_REPO + fly.toml + integration guide cleanup

### DIFF
--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -198,7 +198,7 @@ record = {
 }
 ```
 
-A `darwin_core_sink.py` is on the roadmap for Q3 2026 — see [ROADMAP.md](ROADMAP.md).
+The `integrations/gbif_sink.py` module implements GBIF DarwinCore push out of the box. For iNaturalist see `integrations/inat_sink.py`; for HappyWhale community matching see `integrations/happywhale_sink/`.
 
 ---
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,54 @@
+# fly.toml — EcoMarineAI backend deploy config for Fly.io
+# Usage:
+#   cd whales_be_service
+#   flyctl launch --no-deploy   # first time only — creates the app
+#   flyctl volumes create ecomarine_models --region ams --size 2  # persistent model cache
+#   flyctl deploy               # deploy from project root
+
+app = "ecomarineai-backend"
+primary_region = "ams"
+
+[build]
+  dockerfile = "whales_be_service/Dockerfile"
+  build-target = ""
+
+[env]
+  HF_REPO = "0x0000dead/ecomarineai-cetacean-effb4"
+  ALLOWED_ORIGINS = "*"
+
+[mounts]
+  source = "ecomarine_models"
+  destination = "/app/src/whales_be_service/models"
+
+[[services]]
+  internal_port = 8000
+  protocol = "tcp"
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [services.concurrency]
+    type = "requests"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.http_checks]]
+    interval = "30s"
+    timeout = "10s"
+    grace_period = "300s"
+    path = "/health"
+    method = "GET"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 2048

--- a/render.yaml
+++ b/render.yaml
@@ -5,13 +5,22 @@ services:
     runtime: docker
     dockerfilePath: ./whales_be_service/Dockerfile
     dockerContext: ./whales_be_service
-    plan: free
+    # Use "starter" ($7/mo) to avoid spin-down; free tier causes 5-min cold starts.
+    # For the 7-day availability measurement required by ТЗ §Параметр 7, spin-down
+    # will cause failures each time the instance restarts from idle.
+    plan: starter
     healthCheckPath: /health
     envVars:
+      - key: HF_REPO
+        value: 0x0000dead/ecomarineai-cetacean-effb4
       - key: ALLOWED_ORIGINS
         value: https://ecomarineai-frontend.onrender.com
-      - key: MODEL_DOWNLOAD_URL
-        value: https://huggingface.co/baltsat/Whales-Identification/resolve/main/
+    # Persistent disk keeps model weights between deploys and restarts.
+    # Without this, every cold-start re-downloads ~400 MB from HuggingFace.
+    disk:
+      name: model-cache
+      mountPath: /app/src/whales_be_service/models
+      sizeGB: 2
 
   # Frontend React (nginx)
   - type: web


### PR DESCRIPTION
## Summary

- **render.yaml**: исправлен стейл `MODEL_DOWNLOAD_URL` → `HF_REPO=0x0000dead/ecomarineai-cetacean-effb4`; план `free`→`starter` (без cold-start spin-down — критично для 7-дневного замера Availability ТЗ §Параметр 7); добавлен persistent disk 2 ГБ для кеша весов
- **fly.toml**: новый конфиг деплоя Fly.io — `min_machines_running=1`, volume mount, /health check 300s grace
- **docs/INTEGRATION_GUIDE.md**: убрана устаревшая строка «darwin_core_sink.py is on the roadmap for Q3 2026» — модули gbif_sink, inat_sink, happywhale_sink уже реализованы

## Deploy instructions (для замера Availability)

### Вариант А — Render.com
1. Войти на https://render.com
2. New → Blueprint → выбрать репо → Render найдёт `render.yaml` и создаст оба сервиса
3. Подождать пока backend скачает модели (~5 мин первый запуск)
4. Зарегистрировать в UptimeRobot: Monitor → HTTP(s) → `https://ecomarineai-backend.onrender.com/health` → interval 5 min

### Вариант Б — Fly.io
```bash
cd whales_be_service
flyctl launch --no-deploy
flyctl volumes create ecomarine_models --region ams --size 2
flyctl deploy --config ../fly.toml
```
Мониторинг: Better Stack (betterstack.com) → New monitor → URL `/health` → interval 1 min

После 7 дней: экспортировать CSV/скриншот uptime ≥ 95% → `docs_fsie/availability_report.md`

## Test plan
- [ ] Render Blueprint создаёт оба сервиса без ошибок
- [ ] `/health` возвращает 200 после первого скачивания моделей
- [ ] UptimeRobot начинает мониторинг