### PR TITLE
fix: Fly.io VM 2 vCPU + 4 GB — prevent OOM during warmup

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -47,5 +47,5 @@ primary_region = "ams"
 
 [[vm]]
   cpu_kind = "shared"
-  cpus = 1
-  memory_mb = 2048
+  cpus = 2
+  memory_mb = 4096


### PR DESCRIPTION
CLIP+EffB4+u2net+PyTorch exceeds 2 GB; upgraded to shared-cpu-2x/4096 MB.