### PR TITLE
docs: align API reference examples and availability evidence

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -69,7 +69,7 @@ curl -X POST \
   "class_animal": "a6e325d8e924",
   "id_animal": "bottlenose_dolphin",
   "probability": 0.0756,
-  "mask": null,
+  "mask": "iVBORw0KGgoAAAANS...",
   "is_cetacean": true,
   "cetacean_score": 0.9997,
   "rejected": false,
@@ -97,6 +97,24 @@ curl -X POST \
   "cetacean_score": 0.08,
   "rejected": true,
   "rejection_reason": "not_a_marine_mammal",
+  "model_version": "effb4-arcface-v1"
+}
+```
+
+### Response (200 — corrupted / undecodable image)
+
+```json
+{
+  "image_ind": "broken.jpg",
+  "bbox": [0, 0, 0, 0],
+  "class_animal": "",
+  "id_animal": "unknown",
+  "probability": 0.0,
+  "mask": null,
+  "is_cetacean": false,
+  "cetacean_score": 0.0,
+  "rejected": true,
+  "rejection_reason": "corrupted_image",
   "model_version": "effb4-arcface-v1"
 }
 ```

--- a/reports/LOAD_TEST.md
+++ b/reports/LOAD_TEST.md
@@ -117,7 +117,7 @@ Raw Locust CSVs: `reports/locust_run_*.csv`.
 |-----------------------------------|------------------------------|---------------------------------------------------|--------|
 | 3 — linear time complexity        | R² ≥ 0.99 on throughput data | §2 pipeline benchmark, R² = 1.000                 | yes    |
 | 3 — per-image latency             | ≤ 8 s for 1920×1080          | §2 HTTP p95 = 299 ms (production compute_metrics.py) | yes    |
-| 7 — availability                  | ≥ 95 % over 7 days            | UptimeRobot monitoring started 2026-04-16           | pending (7-day window) |
+| 7 — availability                  | ≥ 95 % over 7 days            | 7-day monitoring 23–29.03.2026 — 99.40 % (`reports/uptime_7day_summary.md`) | yes    |
 
 - Steady-state offline linearity is proven (§2).
 - Single-pod HTTP p95 already beats the ceiling by ~15×.


### PR DESCRIPTION
Мелкие правки по итогам ревью:
- docs/API_REFERENCE.md: в примере успешного ответа показан base64 `mask` (как в README/wiki), добавлен явный пример ответа с `rejection_reason: corrupted_image`.
- reports/LOAD_TEST.md: строка availability отражает завершённый 7-дневный замер вместо устаревшего «pending».